### PR TITLE
Fix gitlab pipeline trigger permissions

### DIFF
--- a/backend/pkg/gitlab/client.go
+++ b/backend/pkg/gitlab/client.go
@@ -1,7 +1,6 @@
 package gitlab
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -44,22 +43,27 @@ func NewClient(baseURL, accessToken, triggerToken, projectID string) *Client {
 	}
 }
 
-// TriggerPipeline triggers a new pipeline in GitLab
+// TriggerPipeline triggers a new pipeline in GitLab using trigger token
+// This method uses the trigger token API which doesn't require special permissions
 func (c *Client) TriggerPipeline(req TriggerPipelineRequest) (*PipelineResponse, error) {
-	url := fmt.Sprintf("%s/api/v4/projects/%s/pipeline", c.baseURL, c.projectID)
+	apiURL := fmt.Sprintf("%s/api/v4/projects/%s/trigger/pipeline", c.baseURL, c.projectID)
 
-	jsonBody, err := json.Marshal(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	// Build form data with trigger token
+	data := url.Values{}
+	data.Set("ref", req.Ref)
+	data.Set("token", c.triggerToken)
+	
+	// Add variables if provided
+	for key, value := range req.Variables {
+		data.Set(fmt.Sprintf("variables[%s]", key), value)
 	}
 
-	httpReq, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonBody))
+	httpReq, err := http.NewRequest("POST", apiURL, strings.NewReader(data.Encode()))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Authorization", "Bearer "+c.accessToken)
+	httpReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 	resp, err := c.client.Do(httpReq)
 	if err != nil {
@@ -70,7 +74,7 @@ func (c *Client) TriggerPipeline(req TriggerPipelineRequest) (*PipelineResponse,
 	bodyBytes, _ := io.ReadAll(resp.Body)
 
 	if resp.StatusCode != http.StatusCreated {
-		return nil, fmt.Errorf("pipeline trigger failed with status: %d", resp.StatusCode)
+		return nil, fmt.Errorf("pipeline trigger failed with status: %d, body: %s", resp.StatusCode, string(bodyBytes))
 	}
 
 	var pipelineResp PipelineResponse
@@ -83,37 +87,12 @@ func (c *Client) TriggerPipeline(req TriggerPipelineRequest) (*PipelineResponse,
 
 // TriggerDomainUpdate triggers a pipeline specifically for domain updates
 func (c *Client) TriggerDomainUpdate(ref string) (*PipelineResponse, error) {
-	apiURL := fmt.Sprintf("%s/api/v4/projects/%s/trigger/pipeline", c.baseURL, c.projectID)
-
-	data := url.Values{}
-	data.Set("ref", ref)
-	data.Set("token", c.triggerToken)
-
-	httpReq, err := http.NewRequest("POST", apiURL, strings.NewReader(data.Encode()))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
+	// Simply call TriggerPipeline with the appropriate request
+	req := TriggerPipelineRequest{
+		Ref:       ref,
+		Variables: nil, // No additional variables for domain updates
 	}
-
-	httpReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-	client := &http.Client{Timeout: 30 * time.Second}
-	resp, err := client.Do(httpReq)
-	if err != nil {
-		return nil, fmt.Errorf("failed to send request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusCreated {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("pipeline trigger failed with status: %d, body: %s", resp.StatusCode, string(body))
-	}
-
-	var pipelineResp PipelineResponse
-	if err := json.NewDecoder(resp.Body).Decode(&pipelineResp); err != nil {
-		return nil, fmt.Errorf("failed to decode response: %w", err)
-	}
-
-	return &pipelineResp, nil
+	return c.TriggerPipeline(req)
 }
 
 // GetPipelineStatus gets the status of a pipeline by ID


### PR DESCRIPTION
Refactor GitLab pipeline triggering to use the correct trigger token API endpoint to resolve permission errors.

The previous implementation of `TriggerPipeline` used the `/api/v4/projects/{id}/pipeline` endpoint with an access token, which requires specific permissions to set pipeline variables and was causing "Insufficient permissions" errors. This PR updates the method to use the `/api/v4/projects/{id}/trigger/pipeline` endpoint with a trigger token, which is designed for external pipeline triggering and does not require these elevated permissions. The `TriggerDomainUpdate` method is also refactored to leverage this corrected `TriggerPipeline` method.

---
<a href="https://cursor.com/background-agent?bcId=bc-562f9a6f-5223-4b8f-aec0-8caa8feb1cec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-562f9a6f-5223-4b8f-aec0-8caa8feb1cec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

