### PR TITLE
Fix ci/cd pipeline trigger for partner domain updates

### DIFF
--- a/.gitlab-ci-domain-update.yml
+++ b/.gitlab-ci-domain-update.yml
@@ -1,9 +1,6 @@
 # Domain Update Pipeline
 # Triggered automatically when partner domains are created/updated/deleted
 
-stages:
-  - domain-update
-
 variables:
   DOCKER_DRIVER: overlay2
   DOCKER_TLS_CERTDIR: ""
@@ -12,7 +9,7 @@ variables:
 
 # Domain Update Pipeline - Triggered by backend API
 deploy:domains-update:
-  stage: domain-update
+  stage: deploy
   image: ubuntu:22.04
   variables:
     DEPLOY_SERVER: $PRODUCTION_SERVER_IP

--- a/docs/DOMAIN_UPDATE_PIPELINE_FIX.md
+++ b/docs/DOMAIN_UPDATE_PIPELINE_FIX.md
@@ -1,0 +1,82 @@
+# Fix for Domain Update Pipeline Trigger Error
+
+## Problem
+The CI/CD pipeline for domain updates was failing with the following error:
+```
+pipeline trigger failed with status: 400, body: {"message":{"base":["deploy:domains-update job: chosen stage domain-update does not exist; available stages are .pre, tests, build, deploy, .post"]}}
+```
+
+## Root Cause
+The `.gitlab-ci-domain-update.yml` file defined a custom stage `domain-update` that doesn't exist in the main `.gitlab-ci.yml` file. GitLab CI doesn't automatically merge stages from included files.
+
+## Solution
+Changed the job `deploy:domains-update` in `.gitlab-ci-domain-update.yml` to use the existing `deploy` stage instead of the non-existent `domain-update` stage.
+
+### Changes Made:
+1. **File: `.gitlab-ci-domain-update.yml`**
+   - Removed the `stages:` section with `domain-update`
+   - Changed `stage: domain-update` to `stage: deploy` for the `deploy:domains-update` job
+
+## How It Works Now
+
+### Pipeline Trigger Flow:
+1. **Partner Create/Update/Delete** → Backend API detects change
+2. **Backend API** → Calls `GitLabClient.TriggerDomainUpdateWithDetails()`
+3. **GitLab API** → Triggers pipeline with variables:
+   - `DOMAIN_UPDATE=true`
+   - `DOMAIN_OPERATION=add|update|delete|refresh`
+   - `OLD_DOMAIN=<old-domain>` (if applicable)
+   - `NEW_DOMAIN=<new-domain>` (if applicable)
+4. **GitLab CI** → Runs `deploy:domains-update` job in `deploy` stage
+5. **Deployment Server** → Executes domain management scripts:
+   - `manage-partner-domains.sh` - Updates nginx configs and SSL certificates
+   - `update-monitoring-config.sh` - Updates monitoring
+   - `health-check.sh` - Verifies everything works
+
+## Testing
+
+### 1. Test Pipeline Trigger Locally:
+```bash
+# Make sure environment variables are set
+export GITLAB_API_URL=https://gitlab.com
+export GITLAB_PROJECT_ID=<your-project-id>
+export GITLAB_TRIGGER_TOKEN=<your-trigger-token>
+
+# Test the trigger
+./scripts/test-gitlab-pipeline-trigger.sh main add "" "newpartner.example.com"
+```
+
+### 2. Test via Backend API:
+Create or update a partner through the admin API, and the pipeline should trigger automatically.
+
+### 3. Validate CI Configuration:
+```bash
+./scripts/validate-gitlab-ci.sh
+```
+
+## Environment Variables Required
+
+For the backend service to trigger pipelines:
+- `GITLAB_API_URL` - GitLab instance URL (e.g., https://gitlab.com)
+- `GITLAB_PROJECT_ID` - Project ID in GitLab
+- `GITLAB_TRIGGER_TOKEN` - Pipeline trigger token from GitLab project settings
+
+## Monitoring
+
+Check pipeline status:
+1. Go to GitLab project → CI/CD → Pipelines
+2. Look for pipelines triggered by "Pipeline triggers API"
+3. Check the `deploy:domains-update` job logs
+
+## Troubleshooting
+
+### If pipeline still fails:
+1. Check that `GITLAB_TRIGGER_TOKEN` is set correctly in backend environment
+2. Verify the trigger token is active in GitLab project settings
+3. Check GitLab CI/CD settings allow pipeline triggers
+4. Review the job logs for specific errors
+
+### Common Issues:
+- **Missing environment variables**: Ensure all required vars are set in GitLab CI/CD settings
+- **SSH access issues**: Check `SSH_PRIVATE_KEY` is set correctly
+- **Script permissions**: Ensure scripts are executable on the deployment server

--- a/scripts/test-gitlab-pipeline-trigger.sh
+++ b/scripts/test-gitlab-pipeline-trigger.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+# Test script to verify GitLab pipeline triggering works correctly
+# This simulates what the backend API does when triggering domain updates
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo -e "${YELLOW}Testing GitLab Pipeline Trigger for Domain Updates${NC}"
+echo "=================================================="
+
+# Check required environment variables
+if [ -z "$GITLAB_API_URL" ]; then
+    echo -e "${RED}Error: GITLAB_API_URL is not set${NC}"
+    exit 1
+fi
+
+if [ -z "$GITLAB_PROJECT_ID" ]; then
+    echo -e "${RED}Error: GITLAB_PROJECT_ID is not set${NC}"
+    exit 1
+fi
+
+if [ -z "$GITLAB_TRIGGER_TOKEN" ]; then
+    echo -e "${RED}Error: GITLAB_TRIGGER_TOKEN is not set${NC}"
+    exit 1
+fi
+
+# Default values
+BRANCH="${1:-main}"
+OPERATION="${2:-refresh}"
+OLD_DOMAIN="${3:-}"
+NEW_DOMAIN="${4:-test.example.com}"
+
+echo "Configuration:"
+echo "  API URL: $GITLAB_API_URL"
+echo "  Project ID: $GITLAB_PROJECT_ID"
+echo "  Branch: $BRANCH"
+echo "  Operation: $OPERATION"
+echo "  Old Domain: $OLD_DOMAIN"
+echo "  New Domain: $NEW_DOMAIN"
+echo ""
+
+# Build the trigger URL
+TRIGGER_URL="${GITLAB_API_URL}/api/v4/projects/${GITLAB_PROJECT_ID}/trigger/pipeline"
+
+# Build form data
+FORM_DATA="token=${GITLAB_TRIGGER_TOKEN}"
+FORM_DATA="${FORM_DATA}&ref=${BRANCH}"
+FORM_DATA="${FORM_DATA}&variables[DOMAIN_UPDATE]=true"
+FORM_DATA="${FORM_DATA}&variables[DOMAIN_OPERATION]=${OPERATION}"
+
+if [ -n "$OLD_DOMAIN" ]; then
+    FORM_DATA="${FORM_DATA}&variables[OLD_DOMAIN]=${OLD_DOMAIN}"
+fi
+
+if [ -n "$NEW_DOMAIN" ]; then
+    FORM_DATA="${FORM_DATA}&variables[NEW_DOMAIN]=${NEW_DOMAIN}"
+fi
+
+echo "Triggering pipeline..."
+echo "URL: $TRIGGER_URL"
+echo ""
+
+# Make the API call
+RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
+    -H "Content-Type: application/x-www-form-urlencoded" \
+    -d "$FORM_DATA" \
+    "$TRIGGER_URL")
+
+# Extract HTTP status code
+HTTP_CODE=$(echo "$RESPONSE" | tail -n 1)
+BODY=$(echo "$RESPONSE" | head -n -1)
+
+echo "Response:"
+echo "  HTTP Status: $HTTP_CODE"
+echo "  Body: $BODY"
+echo ""
+
+# Check if successful
+if [ "$HTTP_CODE" -eq 201 ]; then
+    echo -e "${GREEN}✅ Pipeline triggered successfully!${NC}"
+    
+    # Parse pipeline ID and URL from response
+    PIPELINE_ID=$(echo "$BODY" | grep -o '"id":[0-9]*' | cut -d':' -f2)
+    PIPELINE_URL=$(echo "$BODY" | grep -o '"web_url":"[^"]*' | cut -d'"' -f4)
+    
+    if [ -n "$PIPELINE_ID" ]; then
+        echo "  Pipeline ID: $PIPELINE_ID"
+    fi
+    
+    if [ -n "$PIPELINE_URL" ]; then
+        echo "  Pipeline URL: $PIPELINE_URL"
+    fi
+else
+    echo -e "${RED}❌ Failed to trigger pipeline!${NC}"
+    echo "  Error details: $BODY"
+    exit 1
+fi
+
+echo ""
+echo "Test completed successfully!"

--- a/scripts/validate-gitlab-ci.sh
+++ b/scripts/validate-gitlab-ci.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+
+# Script to validate GitLab CI configuration locally
+# This helps catch configuration errors before pushing to GitLab
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}GitLab CI Configuration Validator${NC}"
+echo "=================================="
+echo ""
+
+# Check if we're in the project root
+if [ ! -f ".gitlab-ci.yml" ]; then
+    echo -e "${RED}Error: .gitlab-ci.yml not found in current directory${NC}"
+    echo "Please run this script from the project root"
+    exit 1
+fi
+
+echo -e "${YELLOW}Checking main CI configuration...${NC}"
+
+# Check for basic YAML syntax (requires python3 and pyyaml)
+if command -v python3 &> /dev/null; then
+    python3 -c "
+import yaml
+import sys
+
+try:
+    with open('.gitlab-ci.yml', 'r') as f:
+        config = yaml.safe_load(f)
+    print('✅ Main .gitlab-ci.yml: Valid YAML syntax')
+    
+    # Check stages
+    if 'stages' in config:
+        print(f'  Stages defined: {config[\"stages\"]}')
+    
+    # Check includes
+    if 'include' in config:
+        print(f'  Includes: {config[\"include\"]}')
+        
+except yaml.YAMLError as e:
+    print(f'❌ Main .gitlab-ci.yml: Invalid YAML syntax')
+    print(f'  Error: {e}')
+    sys.exit(1)
+" || exit 1
+else
+    echo "⚠️  Python3 not found, skipping YAML validation"
+fi
+
+echo ""
+
+# Check domain update CI configuration
+if [ -f ".gitlab-ci-domain-update.yml" ]; then
+    echo -e "${YELLOW}Checking domain update CI configuration...${NC}"
+    
+    if command -v python3 &> /dev/null; then
+        python3 -c "
+import yaml
+import sys
+
+try:
+    with open('.gitlab-ci-domain-update.yml', 'r') as f:
+        config = yaml.safe_load(f)
+    print('✅ .gitlab-ci-domain-update.yml: Valid YAML syntax')
+    
+    # Check for jobs
+    jobs = [k for k in config.keys() if k not in ['stages', 'variables', 'include', 'default']]
+    if jobs:
+        print(f'  Jobs defined: {jobs}')
+        
+        # Check each job's stage
+        for job in jobs:
+            if isinstance(config[job], dict) and 'stage' in config[job]:
+                stage = config[job]['stage']
+                print(f'    {job} uses stage: {stage}')
+                
+                # Warn if stage is not in main stages
+                main_stages = ['tests', 'build', 'deploy']
+                if stage not in main_stages:
+                    print(f'    ⚠️  Warning: Stage \"{stage}\" is not in main stages: {main_stages}')
+                    print(f'       This job will only work when included in main pipeline')
+    
+except yaml.YAMLError as e:
+    print(f'❌ .gitlab-ci-domain-update.yml: Invalid YAML syntax')
+    print(f'  Error: {e}')
+    sys.exit(1)
+" || exit 1
+    fi
+else
+    echo -e "${YELLOW}Domain update CI configuration not found${NC}"
+fi
+
+echo ""
+
+# Check for required scripts
+echo -e "${YELLOW}Checking required scripts...${NC}"
+
+REQUIRED_SCRIPTS=(
+    "scripts/manage-partner-domains.sh"
+    "scripts/update-monitoring-config.sh"
+    "scripts/health-check.sh"
+)
+
+ALL_SCRIPTS_FOUND=true
+for script in "${REQUIRED_SCRIPTS[@]}"; do
+    if [ -f "$script" ]; then
+        echo -e "  ${GREEN}✅${NC} $script found"
+    else
+        echo -e "  ${RED}❌${NC} $script missing"
+        ALL_SCRIPTS_FOUND=false
+    fi
+done
+
+echo ""
+
+# Summary
+echo -e "${BLUE}Summary:${NC}"
+echo "========"
+
+if [ "$ALL_SCRIPTS_FOUND" = true ]; then
+    echo -e "${GREEN}✅ All required scripts are present${NC}"
+else
+    echo -e "${RED}❌ Some required scripts are missing${NC}"
+fi
+
+echo ""
+echo -e "${GREEN}✅ GitLab CI configuration has been updated successfully!${NC}"
+echo ""
+echo -e "${YELLOW}Important changes made:${NC}"
+echo "1. Changed stage from 'domain-update' to 'deploy' in .gitlab-ci-domain-update.yml"
+echo "2. This fixes the error: 'chosen stage domain-update does not exist'"
+echo "3. The job 'deploy:domains-update' will now use the existing 'deploy' stage"
+echo ""
+echo -e "${BLUE}Next steps:${NC}"
+echo "1. Commit and push these changes to GitLab"
+echo "2. Test the pipeline trigger using the test script:"
+echo "   ./scripts/test-gitlab-pipeline-trigger.sh"
+echo "3. Or test via the backend API by creating/updating a partner"


### PR DESCRIPTION
Fix CI/CD pipeline trigger for domain updates by changing the `domain-update` stage to `deploy` in `.gitlab-ci-domain-update.yml`.

The pipeline was failing with a 400 error (`chosen stage domain-update does not exist`) because the custom `domain-update` stage was not defined in the main GitLab CI configuration. Aligning it with the existing `deploy` stage resolves this.

---
<a href="https://cursor.com/background-agent?bcId=bc-e544b4f2-805f-4bfd-b4a5-a6930ef5f17c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e544b4f2-805f-4bfd-b4a5-a6930ef5f17c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

